### PR TITLE
Revert DSND-2231: Improve SonarQube report coverage so it includes ITests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: test-integration test-unit
 .PHONY: test-unit
 test-unit:
 	@# Help: Run unit tests
-	mvn clean verify -Dskip.unit.tests=false -Dskip.integration.tests=false
+	mvn test -Dskip.integration.tests=true
 
 .PHONY: test-integration
 test-integration:
@@ -75,7 +75,7 @@ dist: clean build package
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	@# Help: Run sonar scan on a PR
-	mvn sonar:sonar -P sonar-pr-analysis
+	mvn verify sonar:sonar -P sonar-pr-analysis
 
 .PHONY: sonar
 sonar:

--- a/README.md
+++ b/README.md
@@ -44,18 +44,4 @@ kafka-topics.sh --list --zookeeper zookeeper:2181
 ### Produce kafka test messages locally
 kafka-console-producer.sh --topic delta-topic --broker-list localhost:9092
 
-## Makefile Changes
-The `analyse-pull-request` job on concourse runs when we push code to an open PR and this job runs `make test-unit` AND 
-`make sonar-pr-analysis`.
-
-The issue with this is that `make sonar-pr-analysis` also ran `make verify` which runs both unit and integration tests.
-
-Therefore, this meant the `analyse-pull-request` job on concourse was first running unit tests, then running them again,
-and finally running integration tests. 
-
-To prevent having to run the unit test twice, we can change the `make test-unit` command to run both unit and itests and 
-change the `make sonar-pr-analysis` command to just run the sonar job.
-
-For a more in-depth explanation, please see: https://companieshouse.atlassian.net/wiki/spaces/TEAM4/pages/4357128294/DSND-1990+Tech+Debt+Spike+-+Fix+SonarQube+within+Pom+of+Projects
-
 #


### PR DESCRIPTION
Reverts companieshouse/company-metrics-consumer#54

The inclusion of integration tests during the `run-unit-and-it-tests` job exhausted the available memory resource on the concourse pipeline.

Reverting this PR means that only unit tests are run during the job. Please note, integration tests will not form part of the SonarQube code coverage.