### PR TITLE
DSND-2990: Retry more error types in company metrics consumer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,8 @@
 		<maven-build-helper-plugin.version>3.4.0</maven-build-helper-plugin.version>
 		<maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
 		<ch-kafka.version>1.4.8</ch-kafka.version>
-		<structured-logging.version>1.9.27</structured-logging.version>
+		<structured-logging.version>1.9.37</structured-logging.version>
+		<maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
 		<kafka-models.version>1.0.38</kafka-models.version>
 		<private-api-sdk-java.version>2.0.423</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.9</api-sdk-manager-java-library.version>
@@ -231,7 +232,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.17</version>
+					<version>${maven-checkstyle-plugin.version}</version>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -398,7 +399,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
+				<version>${maven-checkstyle-plugin.version}</version>
 				<executions>
 					<execution>
 						<phase>process-sources</phase>

--- a/src/itest/java/uk/gov/companieshouse/company/metrics/steps/AppointmentSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/company/metrics/steps/AppointmentSteps.java
@@ -130,19 +130,14 @@ public class AppointmentSteps {
         assertMetricsApiSuccessfullyInvoked(serverEvents);
     }
 
-    @Given("The consumer has been configured with api key without internal app privileges for {string}")
-    public void consumerBeenConfiguredAsUnauthorised(String companyNumber) {
-        stubCompanyMetricsApi(HttpStatus.UNAUTHORIZED.value());
-    }
-
     @Given("The message resource Uri {string} is invalid")
     public void theMessageResourceURIIsInvalid(String invalidResourceUri) {
         CONTEXT.set(COMPANY_METRICS_RECALCULATE_URI, invalidResourceUri);
     }
 
-    @Given("The specified endpoint does not exist within company metrics api")
-    public void theSpecifiedEndpointWithinMessageDoesNotExistWithinMetricsConsumer() {
-        stubCompanyMetricsApi(HttpStatus.NOT_FOUND.value());
+    @Given("Company Metrics API returns CONFLICT status code")
+    public void companyMetricsApiReturnsConflictStatusCode() {
+        stubCompanyMetricsApi(HttpStatus.CONFLICT.value());
     }
 
     private void stubCompanyMetricsApi(int statusCode) {

--- a/src/itest/resources/features/company-metrics-appointments.feature
+++ b/src/itest/resources/features/company-metrics-appointments.feature
@@ -2,8 +2,8 @@ Feature: Company metrics appointment criteria
 
   Scenario Outline: Post officers recalculate successfully - event type changed
     Given The event type is "<eventType>"
-    And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     And Company Metrics API returns OK status code
+    And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then A request is sent to the Company Metrics Recalculate endpoint
 
@@ -15,8 +15,8 @@ Feature: Company metrics appointment criteria
 
   Scenario Outline: Post officers recalculate successfully - event type deleted
     Given The event type is "<eventType>"
-    And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     And Company Metrics API returns OK status code
+    And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then A request is sent to the Company Metrics Recalculate endpoint
 
@@ -33,8 +33,8 @@ Feature: Company metrics appointment criteria
     Then A non-retryable exception should be thrown when consuming from "stream-company-officers"
     And The message should be placed on to "stream-company-officers-company-metrics-consumer-invalid" kafka topic
 
-  Scenario Outline: Service not authenticated or authorised
-    Given The consumer has been configured with api key without internal app privileges for "<companyNumber>"
+  Scenario Outline: Metrics Api returns 400 bad request
+    Given Company Metrics API returns BAD_REQUEST status code
     And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then The message should be placed on to "stream-company-officers-company-metrics-consumer-invalid" kafka topic
@@ -58,8 +58,8 @@ Feature: Company metrics appointment criteria
       | stream-company-officers | SC109614      | abcdefg                            |
 
 
-  Scenario Outline: Endpoint does not exist/could not be found in metrics api
-    Given The specified endpoint does not exist within company metrics api
+  Scenario Outline: Metrics Api returns 409 conflict
+    Given Company Metrics API returns CONFLICT status code
     And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then The message should be placed on to "stream-company-officers-company-metrics-consumer-invalid" kafka topic

--- a/src/itest/resources/features/company-metrics-psc-statements.feature
+++ b/src/itest/resources/features/company-metrics-psc-statements.feature
@@ -2,8 +2,8 @@ Feature: Company metrics PSC statements statements criteria
 
   Scenario Outline: Post psc statements recalculate successfully - event type changed
     Given The event type is "<eventType>"
-    And A resource change data message for "<companyNumber>" with an psc entity exists on the "<mainKafkaTopic>" kafka topic
     And Company Metrics API returns OK status code
+    And A resource change data message for "<companyNumber>" with an psc entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then A request is sent to the Company Metrics Recalculate endpoint for PSCs
 

--- a/src/itest/resources/features/company-metrics-psc.feature
+++ b/src/itest/resources/features/company-metrics-psc.feature
@@ -10,8 +10,8 @@ Feature: Company metrics PSC criteria
 
   Scenario Outline: Post psc recalculate successfully - event type changed
     Given The event type is "<eventType>"
-    And A resource change data message for "<companyNumber>" with an psc entity exists on the "<mainKafkaTopic>" kafka topic
     And Company Metrics API returns OK status code
+    And A resource change data message for "<companyNumber>" with an psc entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then A request is sent to the Company Metrics Recalculate endpoint for PSCs
 
@@ -23,8 +23,8 @@ Feature: Company metrics PSC criteria
 
   Scenario Outline: Post psc recalculate successfully - event type deleted
     Given The event type is "<eventType>"
-    And A resource change data message for "<companyNumber>" with an psc entity exists on the "<mainKafkaTopic>" kafka topic
     And Company Metrics API returns OK status code
+    And A resource change data message for "<companyNumber>" with an psc entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then A request is sent to the Company Metrics Recalculate endpoint for PSCs
 
@@ -34,8 +34,8 @@ Feature: Company metrics PSC criteria
       | stream-company-psc | deleted    | 08124207      |
       | stream-company-psc | deleted    | SC109614      |
 
-  Scenario Outline: Service not authenticated or authorised
-    Given The consumer has been configured with api key without internal app privileges for "<companyNumber>"
+  Scenario Outline: Metrics Api returns 400 bad request
+    Given Company Metrics API returns BAD_REQUEST status code
     And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then The message should be placed on to "stream-company-psc-company-metrics-consumer-invalid" kafka topic
@@ -58,14 +58,14 @@ Feature: Company metrics PSC criteria
       | stream-company-psc | 08124207      | /companyabc/%s/metrics/recalculate |
       | stream-company-psc | SC109614      | abcdefg                            |
 
-  Scenario Outline: Endpoint does not exist/could not be found in metrics api
-    Given The specified endpoint does not exist within company metrics api
+  Scenario Outline: Metrics Api returns 409 conflict
+    Given Company Metrics API returns CONFLICT status code
     And A resource change data message for "<companyNumber>" with an appointment entity exists on the "<mainKafkaTopic>" kafka topic
     When The message is consumed
     Then The message should be placed on to "stream-company-psc-company-metrics-consumer-invalid" kafka topic
 
     Examples:
-      | mainKafkaTopic          | companyNumber |
+      | mainKafkaTopic     | companyNumber |
       | stream-company-psc | 01203396      |
       | stream-company-psc | 08124207      |
       | stream-company-psc | SC109614      |

--- a/src/main/java/uk/gov/companieshouse/company/metrics/service/MetricsApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/service/MetricsApiResponseHandler.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.company.metrics.service;
 
 import static uk.gov.companieshouse.company.metrics.CompanyMetricsConsumerApplication.NAMESPACE;
 
-import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -12,12 +11,14 @@ import uk.gov.companieshouse.company.metrics.exception.RetryableErrorException;
 import uk.gov.companieshouse.company.metrics.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import java.util.Arrays;
 
 @Component
 public class MetricsApiResponseHandler implements ResponseHandler {
 
     private static final String FAILED_MSG = "Failed recalculating %s for company %s";
-    private static final String ERROR_MSG = "Error %s recalculating %s for company %s";
+    private static final String ERROR_MSG = "HTTP response code %s  when recalculating %s for company %s";
+    private static final String API_INFO_RESPONSE_MSG = "Call to API failed, status code: %d. %s";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
@@ -26,8 +27,8 @@ public class MetricsApiResponseHandler implements ResponseHandler {
      * URIValidationException is caught in the client.
      *
      * @param companyNumber The company number for the delta that has come through on the topic.
-     * @param deltaType The type of delta that has come through on the topic.
-     * @param ex The exception that was caught in the client.
+     * @param deltaType     The type of delta that has come through on the topic.
+     * @param ex            The exception that was caught in the client.
      */
     @Override
     public void handle(String companyNumber, String deltaType, URIValidationException ex) {
@@ -41,8 +42,8 @@ public class MetricsApiResponseHandler implements ResponseHandler {
      * IllegalArgumentException is caught in the client.
      *
      * @param companyNumber The company number for the delta that has come through on the topic.
-     * @param deltaType The type of delta that has come through on the topic.
-     * @param ex The exception that was caught in the client.
+     * @param deltaType     The type of delta that has come through on the topic.
+     * @param ex            The exception that was caught in the client.
      */
     @Override
     public void handle(String companyNumber, String deltaType, IllegalArgumentException ex) {
@@ -58,20 +59,20 @@ public class MetricsApiResponseHandler implements ResponseHandler {
      * when an ApiErrorResponseException is caught in the client.
      *
      * @param companyNumber The company number for the delta that has come through on the topic.
-     * @param deltaType The type of delta that has come through on the topic.
-     * @param ex The exception that was caught in the client.
+     * @param deltaType     The type of delta that has come through on the topic.
+     * @param ex            The exception that was caught in the client.
      */
     @Override
     public void handle(String companyNumber, String deltaType, ApiErrorResponseException ex) {
-        String message = String.format(ERROR_MSG, ex.getStatusCode(), deltaType, companyNumber);
-        Map<String, Object> logMap = DataMapHolder.getLogMap();
-        logMap.put("status", ex.getStatusCode());
-        if (HttpStatus.valueOf(ex.getStatusCode()).is5xxServerError()) {
-            LOGGER.info(message, logMap);
-            throw new RetryableErrorException(message, ex);
+        String errorMessage = String.format(ERROR_MSG, ex.getStatusCode(), deltaType, companyNumber);
+        String infoMessage = String.format(API_INFO_RESPONSE_MSG, ex.getStatusCode(), Arrays.toString(ex.getStackTrace()));
+        DataMapHolder.getLogMap().put("status", ex.getStatusCode());
+        if (HttpStatus.BAD_REQUEST.value() == ex.getStatusCode() || HttpStatus.CONFLICT.value() == ex.getStatusCode()) {
+            LOGGER.error(errorMessage, DataMapHolder.getLogMap());
+            throw new NonRetryableErrorException(errorMessage, ex);
         } else {
-            LOGGER.error(message, logMap);
-            throw new NonRetryableErrorException(message, ex);
+            LOGGER.info(infoMessage, DataMapHolder.getLogMap());
+            throw new RetryableErrorException(infoMessage, ex);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company/metrics/service/MetricsApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/company/metrics/service/MetricsApiResponseHandler.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company.metrics.service;
 
 import static uk.gov.companieshouse.company.metrics.CompanyMetricsConsumerApplication.NAMESPACE;
 
+import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -11,13 +12,13 @@ import uk.gov.companieshouse.company.metrics.exception.RetryableErrorException;
 import uk.gov.companieshouse.company.metrics.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-import java.util.Arrays;
 
 @Component
 public class MetricsApiResponseHandler implements ResponseHandler {
 
     private static final String FAILED_MSG = "Failed recalculating %s for company %s";
-    private static final String ERROR_MSG = "HTTP response code %s  when recalculating %s for company %s";
+    private static final String ERROR_MSG = "HTTP response code %s  when recalculating %s for "
+            + "company %s";
     private static final String API_INFO_RESPONSE_MSG = "Call to API failed, status code: %d. %s";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
@@ -64,10 +65,13 @@ public class MetricsApiResponseHandler implements ResponseHandler {
      */
     @Override
     public void handle(String companyNumber, String deltaType, ApiErrorResponseException ex) {
-        String errorMessage = String.format(ERROR_MSG, ex.getStatusCode(), deltaType, companyNumber);
-        String infoMessage = String.format(API_INFO_RESPONSE_MSG, ex.getStatusCode(), Arrays.toString(ex.getStackTrace()));
+        String errorMessage = String.format(ERROR_MSG, ex.getStatusCode(),
+                deltaType, companyNumber);
+        String infoMessage = String.format(API_INFO_RESPONSE_MSG, ex.getStatusCode(),
+                Arrays.toString(ex.getStackTrace()));
         DataMapHolder.getLogMap().put("status", ex.getStatusCode());
-        if (HttpStatus.BAD_REQUEST.value() == ex.getStatusCode() || HttpStatus.CONFLICT.value() == ex.getStatusCode()) {
+        if (HttpStatus.BAD_REQUEST.value() == ex.getStatusCode()
+                || HttpStatus.CONFLICT.value() == ex.getStatusCode()) {
             LOGGER.error(errorMessage, DataMapHolder.getLogMap());
             throw new NonRetryableErrorException(errorMessage, ex);
         } else {

--- a/src/test/java/uk/gov/companieshouse/company/metrics/service/MetricsApiResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company/metrics/service/MetricsApiResponseHandlerTest.java
@@ -16,12 +16,14 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.company.metrics.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.company.metrics.exception.RetryableErrorException;
+import java.util.Arrays;
 
 @ExtendWith(MockitoExtension.class)
 class MetricsApiResponseHandlerTest {
 
     private static final String FAILED_MSG = "Failed recalculating %s for company %s";
-    private static final String ERROR_MSG = "Error %s recalculating %s for company %s";
+    private static final String ERROR_MSG = "HTTP response code %s  when recalculating %s for company %s";
+    private static final String API_INFO_RESPONSE_MSG = "Call to API failed, status code: %d. %s";
     private static final String COMPANY_NUMBER = "12345678";
     private static final String APPOINTMENTS_DELTA_TYPE = "appointments";
 
@@ -81,11 +83,12 @@ class MetricsApiResponseHandlerTest {
     void testHandleApiErrorResponseExceptionWhenStatusCode500() {
         // given
         final int statusCodeInternalServerError = 500;
-        String message = String.format(ERROR_MSG, statusCodeInternalServerError, APPOINTMENTS_DELTA_TYPE, COMPANY_NUMBER);
         HttpResponseException.Builder builder = new HttpResponseException.Builder(statusCodeInternalServerError, "", new HttpHeaders());
+        ApiErrorResponseException exception = new ApiErrorResponseException(builder);
+        String message = String.format(API_INFO_RESPONSE_MSG, statusCodeInternalServerError, Arrays.toString(exception.getStackTrace()));
 
         // when
-        Executable actual = () -> metricsApiResponseHandler.handle(COMPANY_NUMBER, APPOINTMENTS_DELTA_TYPE, new ApiErrorResponseException(builder));
+        Executable actual = () -> metricsApiResponseHandler.handle(COMPANY_NUMBER, APPOINTMENTS_DELTA_TYPE, exception);
 
         // then
         Exception ex = assertThrows(RetryableErrorException.class, actual);
@@ -93,9 +96,25 @@ class MetricsApiResponseHandlerTest {
     }
 
     @Test
-    void testHandleApiErrorResponseExceptionWhenStatusCode404() {
+    void testHandleApiErrorResponseExceptionWhenStatusCodeIsNot400Or409() {
         // given
-        final int statusCodeNotFound = 404;
+        final int statusCodeForbidden = 403;
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(statusCodeForbidden, "", new HttpHeaders());
+        ApiErrorResponseException exception = new ApiErrorResponseException(builder);
+        String message = String.format(API_INFO_RESPONSE_MSG, statusCodeForbidden, Arrays.toString(exception.getStackTrace()));
+
+        // when
+        Executable actual = () -> metricsApiResponseHandler.handle(COMPANY_NUMBER, APPOINTMENTS_DELTA_TYPE, exception);
+
+        // then
+        Exception ex = assertThrows(RetryableErrorException.class, actual);
+        assertEquals(message, ex.getMessage());
+    }
+
+    @Test
+    void testHandleApiErrorResponseExceptionWhenStatusCode409() {
+        // given
+        final int statusCodeNotFound = 409;
         String message = String.format(ERROR_MSG, statusCodeNotFound, APPOINTMENTS_DELTA_TYPE, COMPANY_NUMBER);
         HttpResponseException.Builder builder = new HttpResponseException.Builder(statusCodeNotFound, "", new HttpHeaders());
 
@@ -108,11 +127,11 @@ class MetricsApiResponseHandlerTest {
     }
 
     @Test
-    void testHandleApiErrorResponseExceptionWhenStatusCodeIsNot404Or5xx() {
+    void testHandleApiErrorResponseExceptionWhenStatusCode400() {
         // given
-        final int statusCodeForbidden = 403;
-        String message = String.format(ERROR_MSG, statusCodeForbidden, APPOINTMENTS_DELTA_TYPE, COMPANY_NUMBER);
-        HttpResponseException.Builder builder = new HttpResponseException.Builder(statusCodeForbidden, "", new HttpHeaders());
+        final int statusCodeNotFound = 400;
+        String message = String.format(ERROR_MSG, statusCodeNotFound, APPOINTMENTS_DELTA_TYPE, COMPANY_NUMBER);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(statusCodeNotFound, "", new HttpHeaders());
 
         // when
         Executable actual = () -> metricsApiResponseHandler.handle(COMPANY_NUMBER, APPOINTMENTS_DELTA_TYPE, new ApiErrorResponseException(builder));


### PR DESCRIPTION
* all error types apart from 400 and 409 will now cause RetryableErrorException
* cucumber tests needed fixing and making more specific to this new retry behaviour 

[DSND-2990](https://companieshouse.atlassian.net/browse/DSND-2990)

[DSND-2990]: https://companieshouse.atlassian.net/browse/DSND-2990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ