### PR TITLE
Updated Makefile for dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ help:
         | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' \
         | xargs -I _ sh -c 'printf "%-20s " _; make _ -nB | (grep -i "^# Help:" || echo "") | tail -1 | sed "s/^# Help: //g"'
 
-dependency_check_runner := 416670754337.dkr.ecr.eu-west-2.amazonaws.com/dependency-check-runner
-
 .PHONY: all
 all:
 	@# Help: Calls methods required to build a locally runnable version, typically the build target
@@ -120,11 +118,4 @@ lint: lint/docker-compose sonar
 lint/docker-compose:
 	@# Help: Lint docker file
 	docker-compose -f docker-compose.yml config
-
-.PHONY: dependency-check
-dependency-check:
-	docker run --rm -e DEPENDENCY_CHECK_SUPPRESSIONS_HOME=/opt -v "$$(pwd)":/app -w /app ${dependency_check_runner} --repo-name="$(basename "$$(pwd)")"
-
-.PHONY: security-check
-security-check: dependency-check
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>companies-house-parent</artifactId>
-    <version>2.1.11</version>
+    <version>2.1.12</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Updated Makefile to roll over to latest version of dependency-check feature for centralized vulnerability scanning. 